### PR TITLE
feat(exit): #136 expose exit api

### DIFF
--- a/wasm/build-scripts/build-ffmpeg.sh
+++ b/wasm/build-scripts/build-ffmpeg.sh
@@ -22,6 +22,7 @@ FLAGS=(
   -s EXPORTED_FUNCTIONS="[_main, _proxy_main]"  # export main and proxy_main funcs
   -s EXTRA_EXPORTED_RUNTIME_METHODS="[FS, cwrap, ccall, setValue, writeAsciiToMemory]"   # export preamble funcs
   -s INITIAL_MEMORY=2146435072                  # 64 KB * 1024 * 16 * 2047 = 2146435072 bytes ~= 2 GB
+  --post-js wasm/post-js.js
   $OPTIM_FLAGS
 )
 echo "FFMPEG_EM_FLAGS=${FLAGS[@]}"

--- a/wasm/post-js.js
+++ b/wasm/post-js.js
@@ -1,0 +1,1 @@
+Module["exit"] = exit;


### PR DESCRIPTION
expose an internal function `exit` in emscripten glue code. see [discussions](https://github.com/ffmpegwasm/ffmpeg.wasm/issues/136) for details.