### PR TITLE
Revert "Upgrade to emscripten v2.0.24"

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-EM_VERSION=2.0.24
+EM_VERSION=2.0.8
 
 docker pull emscripten/emsdk:$EM_VERSION
 docker run \

--- a/wasm/build-scripts/build-ffmpeg.sh
+++ b/wasm/build-scripts/build-ffmpeg.sh
@@ -5,6 +5,7 @@ source $(dirname $0)/var.sh
 
 if [[ "$FFMPEG_ST" != "yes" ]]; then
   mkdir -p wasm/packages/core/dist
+  EXPORTED_FUNCTIONS="[_main, _proxy_main]"
   EXTRA_FLAGS=(
     -pthread
     -s USE_PTHREADS=1                             # enable pthreads support
@@ -13,6 +14,7 @@ if [[ "$FFMPEG_ST" != "yes" ]]; then
   )
 else
   mkdir -p wasm/packages/core-st/dist
+  EXPORTED_FUNCTIONS="[_main]"
   EXTRA_FLAGS=(
     -o wasm/packages/core-st/dist/ffmpeg-core.js
   )
@@ -28,11 +30,11 @@ FLAGS=(
   -s EXIT_RUNTIME=1                             # exit runtime after execution
   -s MODULARIZE=1                               # use modularized version to be more flexible
   -s EXPORT_NAME="createFFmpegCore"             # assign export name for browser
-  -s EXPORTED_FUNCTIONS="[_main]"  # export main and proxy_main funcs
-  -s EXPORTED_RUNTIME_METHODS="[FS, cwrap, ccall, setValue, writeAsciiToMemory]"   # export preamble funcs
+  -s EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS"  # export main and proxy_main funcs
+  -s EXTRA_EXPORTED_RUNTIME_METHODS="[FS, cwrap, ccall, setValue, writeAsciiToMemory]"   # export preamble funcs
   -s INITIAL_MEMORY=2146435072                  # 64 KB * 1024 * 16 * 2047 = 2146435072 bytes ~= 2 GB
-  --pre-js wasm/src/pre.js
   --post-js wasm/src/post.js
+  --pre-js wasm/src/pre.js
   $OPTIM_FLAGS
   ${EXTRA_FLAGS[@]}
 )

--- a/wasm/tests/utils/mt/index.js
+++ b/wasm/tests/utils/mt/index.js
@@ -3,7 +3,7 @@ let resolve = null;
 
 const ffmpeg = ({ core, args }) => new Promise((_resolve) => {
   core.ccall(
-    'emscripten_proxy_main',  // use emscripten_proxy_main if emscripten upgraded
+    'proxy_main',  // use emscripten_proxy_main if emscripten upgraded
     'number',
     ['number', 'number'],
     parseArgs(core, ['ffmpeg', '-hide_banner', '-nostdin', ...args]),


### PR DESCRIPTION
Hi.

Revert some files around "proxy_main".
Because of confusing due to API changes.

I want to use this wasm from the `ffmpeg.wasm` package.

It will close https://github.com/ffmpegwasm/ffmpeg.wasm/issues/357