### PR TITLE
set `EXIT_RUNTIME=0` to avoid runtime exit after first run

### DIFF
--- a/wasm/build-scripts/build-ffmpeg.sh
+++ b/wasm/build-scripts/build-ffmpeg.sh
@@ -31,7 +31,7 @@ FLAGS=(
   fftools/ffmpeg_opt.c fftools/ffmpeg_filter.c fftools/ffmpeg_hw.c fftools/cmdutils.c fftools/ffmpeg.c
   -s USE_SDL=2                                  # use SDL2
   -s INVOKE_RUN=0                               # not to run the main() in the beginning
-  -s EXIT_RUNTIME=1                             # exit runtime after execution
+  -s EXIT_RUNTIME=0                             # exit runtime after execution
   -s MODULARIZE=1                               # use modularized version to be more flexible
   -s EXPORT_NAME="createFFmpegCore"             # assign export name for browser
   -s EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS"  # export main and proxy_main funcs


### PR DESCRIPTION
> Hi there,
> 
> Has anyone encountered issues calling ffmpeg.run() multiple times?
> 
> The first time i call ffmpeg.run() it works, the 2nd time i call ffmpeg.run() in the web worker it throws the following error; `[fferr] Assertion failed: native function 'malloc' called after runtime exit (use NO_EXIT_RUNTIME to keep it alive after main() exits)`

_Originally posted by @merri-ment in https://github.com/ffmpegwasm/ffmpeg.wasm/issues/341#issuecomment-1144117335_
